### PR TITLE
[bugfix] include Name attr in payload only when it is set 

### DIFF
--- a/models/schema_template_externalepg_subnet.go
+++ b/models/schema_template_externalepg_subnet.go
@@ -10,9 +10,12 @@ func NewTemplateExternalEpgSubnet(ops, path, ip, name string, scope, aggregate [
 	var bdsubnetMap map[string]interface{}
 	bdsubnetMap = map[string]interface{}{
 		"ip":        ip,
-		"name":      name,
 		"scope":     scope,
 		"aggregate": aggregate,
+	}
+
+	if name != "" {
+		bdsubnetMap["name"] = name
 	}
 
 	return &ExternalEpgSubnet{


### PR DESCRIPTION
add condition to check whether Name attribute is set while creating schema template external epg subnet.
If name exist, include it in payload