### PR TITLE
Add mutex to ensure POST/PUT/PATCH/DELETE operations are executed in sequence

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/ciscoecosystem/mso-go-client/container"
 	"github.com/ciscoecosystem/mso-go-client/models"
+	"github.com/hashicorp/go-version"
 )
 
 const msoAuthPayload = `{
@@ -39,6 +40,7 @@ type Client struct {
 	proxyUrl           string
 	domain             string
 	platform           string
+	version            string
 	skipLoggingPayload bool
 }
 
@@ -74,6 +76,12 @@ func Domain(domain string) Option {
 func Platform(platform string) Option {
 	return func(client *Client) {
 		client.platform = platform
+	}
+}
+
+func Version(version string) Option {
+	return func(client *Client) {
+		client.version = version
 	}
 }
 
@@ -287,6 +295,52 @@ func (c *Client) GetDomainId(domain string) (string, error) {
 		}
 	}
 	return "", fmt.Errorf("Unable to find domain id for domain %s", domain)
+}
+
+func (c *Client) GetVersion() (string, error) {
+	req, err := c.MakeRestRequest("GET", "/api/v1/platform/version", nil, true)
+	if err != nil {
+		return "unknown", err
+	}
+
+	obj, _, err := c.Do(req)
+	if err != nil {
+		return "unknown", err
+	}
+
+	err = CheckForErrors(obj, "GET")
+	if err != nil {
+		return "unknown", err
+	}
+
+	version := stripQuotes(obj.Search("version").String())
+	if version == "" {
+		return "unknown", fmt.Errorf("Unable to identify version")
+	}
+	c.version = version
+	return version, nil
+}
+
+// Compares the version to the retrieved version.
+// This returns -1, 0, or 1 if this version is smaller, equal, or larger than the retrieved version, respectively.
+func (c *Client) CompareVersion(v string) (int, error) {
+	if c.version == "" {
+		c.GetVersion()
+	}
+	if c.version == "unknown" {
+		return 0, fmt.Errorf("Could not retrieve version")
+	}
+
+	v1, err := version.NewVersion(c.version)
+	if err != nil {
+		return 0, fmt.Errorf("Could not parse retrieved version")
+	}
+	v2, err := version.NewVersion(v)
+	if err != nil {
+		return 0, fmt.Errorf("Could not parse version")
+	}
+
+	return v2.Compare(v1), nil
 }
 
 func StrtoInt(s string, startIndex int, bitSize int) (int64, error) {

--- a/client/client.go
+++ b/client/client.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/ciscoecosystem/mso-go-client/container"
 	"github.com/ciscoecosystem/mso-go-client/models"
@@ -31,6 +32,7 @@ type Client struct {
 	BaseURL            *url.URL
 	httpClient         *http.Client
 	AuthToken          *Auth
+	Mutex              sync.Mutex
 	username           string
 	password           string
 	insecure           bool

--- a/client/client_service.go
+++ b/client/client_service.go
@@ -95,9 +95,7 @@ func (c *Client) DeletebyId(url string) error {
 		return err
 	}
 
-	c.Mutex.Lock()
 	_, resp, err1 := c.Do(req)
-	c.Mutex.Unlock()
 	if err1 != nil {
 		return err1
 	}

--- a/client/client_service.go
+++ b/client/client_service.go
@@ -67,9 +67,7 @@ func (c *Client) Save(endpoint string, obj models.Model) (*container.Container, 
 		return nil, err
 	}
 
-	c.Mutex.Lock()
 	cont, _, err := c.Do(req)
-	c.Mutex.Unlock()
 	if err != nil {
 		return nil, err
 	}

--- a/client/client_service.go
+++ b/client/client_service.go
@@ -45,7 +45,9 @@ func (c *Client) Put(endpoint string, obj models.Model) (*container.Container, e
 		return nil, err
 	}
 
+	c.Mutex.Lock()
 	cont, _, err := c.Do(req)
+	c.Mutex.Unlock()
 	if err != nil {
 		return nil, err
 	}
@@ -65,7 +67,9 @@ func (c *Client) Save(endpoint string, obj models.Model) (*container.Container, 
 		return nil, err
 	}
 
+	c.Mutex.Lock()
 	cont, _, err := c.Do(req)
+	c.Mutex.Unlock()
 	if err != nil {
 		return nil, err
 	}
@@ -93,7 +97,9 @@ func (c *Client) DeletebyId(url string) error {
 		return err
 	}
 
+	c.Mutex.Lock()
 	_, resp, err1 := c.Do(req)
+	c.Mutex.Unlock()
 	if err1 != nil {
 		return err1
 	}
@@ -132,7 +138,9 @@ func (c *Client) PatchbyID(endpoint string, objList ...models.Model) (*container
 		return nil, err
 	}
 
+	c.Mutex.Lock()
 	cont, _, err := c.Do(req)
+	c.Mutex.Unlock()
 	if err != nil {
 		return nil, err
 	}

--- a/client/schema_site_anp_epg_useg_attr_service.go
+++ b/client/schema_site_anp_epg_useg_attr_service.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"fmt"
-	"sync"
 
 	"github.com/ciscoecosystem/mso-go-client/models"
 )

--- a/client/schema_site_l3_out_service.go
+++ b/client/schema_site_l3_out_service.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"fmt"
-	"sync"
 
 	"github.com/ciscoecosystem/mso-go-client/models"
 )

--- a/client/schema_site_vrf_region_hub_network_service.go
+++ b/client/schema_site_vrf_region_hub_network_service.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"fmt"
-	"sync"
 
 	"github.com/ciscoecosystem/mso-go-client/models"
 )

--- a/go.mod
+++ b/go.mod
@@ -2,3 +2,4 @@ module github.com/ciscoecosystem/mso-go-client
 
 go 1.12
 
+require github.com/hashicorp/go-version v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=
+github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=


### PR DESCRIPTION
A mutex is added to ensure API write operations are always executed in sequence due to the underlying API requiring this. When being used with Terraform, this avoids the previously mandatory use of the `-parallelism=1` CLI argument.

Also adding a CompareVersion() function to potentially relax the mutex requirement for future versions.