### PR TITLE
Added SiteContractServiceGraphListener structure to manage the Azure CNC listeners

### DIFF
--- a/models/schema_template_contract_service_graph.go
+++ b/models/schema_template_contract_service_graph.go
@@ -66,39 +66,21 @@ func (graphAttr *SiteContractServiceGraph) ToMap() (map[string]interface{}, erro
 	return graphAttrMap, nil
 }
 
-type SiteContractServiceGraphListener struct {
-	Ops   string                 `json:",omitempty"`
-	Path  string                 `json:",omitempty"`
-	Value map[string]interface{} `json:",omitempty"`
-}
+func NewSiteContractServiceGraphListener(ops, path, name, protocol, securityPolicy string, port int, certificates []interface{}, rules []interface{}, frontendIpDnMap map[string]string) *PatchPayload {
 
-func NewSiteContractServiceGraphListener(ops, path, name, protocol, securityPolicy string, port int, certificates []interface{}, rules []interface{}, frontendIpDnMap map[string]string) *SiteContractServiceGraphListener {
-	var listenerMap map[string]interface{}
-	if ops != "remove" {
-		listenerMap = map[string]interface{}{
-			"name":         name,
-			"port":         port,
-			"protocol":     protocol,
-			"secPolicy":    securityPolicy,
-			"certificates": certificates,
-			"rules":        rules,
-			"nlbDevIp":     frontendIpDnMap,
-		}
+	listenerMap := map[string]interface{}{
+		"name":         name,
+		"port":         port,
+		"protocol":     protocol,
+		"secPolicy":    securityPolicy,
+		"certificates": certificates,
+		"rules":        rules,
+		"nlbDevIp":     frontendIpDnMap,
 	}
 
-	return &SiteContractServiceGraphListener{
+	return &PatchPayload{
 		Ops:   ops,
 		Path:  path,
 		Value: listenerMap,
 	}
-}
-
-func (listenerAttr *SiteContractServiceGraphListener) ToMap() (map[string]interface{}, error) {
-	listenerAttrMap := make(map[string]interface{})
-	A(listenerAttrMap, "op", listenerAttr.Ops)
-	A(listenerAttrMap, "path", listenerAttr.Path)
-	if listenerAttr.Value != nil {
-		A(listenerAttrMap, "value", listenerAttr.Value)
-	}
-	return listenerAttrMap, nil
 }

--- a/models/schema_template_contract_service_graph.go
+++ b/models/schema_template_contract_service_graph.go
@@ -65,3 +65,40 @@ func (graphAttr *SiteContractServiceGraph) ToMap() (map[string]interface{}, erro
 
 	return graphAttrMap, nil
 }
+
+type SiteContractServiceGraphListener struct {
+	Ops   string                 `json:",omitempty"`
+	Path  string                 `json:",omitempty"`
+	Value map[string]interface{} `json:",omitempty"`
+}
+
+func NewSiteContractServiceGraphListener(ops, path, name, protocol, securityPolicy string, port int, certificates []interface{}, rules []interface{}, frontendIpDnMap map[string]string) *SiteContractServiceGraphListener {
+	var listenerMap map[string]interface{}
+	if ops != "remove" {
+		listenerMap = map[string]interface{}{
+			"name":         name,
+			"port":         port,
+			"protocol":     protocol,
+			"secPolicy":    securityPolicy,
+			"certificates": certificates,
+			"rules":        rules,
+			"nlbDevIp":     frontendIpDnMap,
+		}
+	}
+
+	return &SiteContractServiceGraphListener{
+		Ops:   ops,
+		Path:  path,
+		Value: listenerMap,
+	}
+}
+
+func (listenerAttr *SiteContractServiceGraphListener) ToMap() (map[string]interface{}, error) {
+	listenerAttrMap := make(map[string]interface{})
+	A(listenerAttrMap, "op", listenerAttr.Ops)
+	A(listenerAttrMap, "path", listenerAttr.Path)
+	if listenerAttr.Value != nil {
+		A(listenerAttrMap, "value", listenerAttr.Value)
+	}
+	return listenerAttrMap, nil
+}


### PR DESCRIPTION
Note:

Added SiteContractServiceGraphListener structure to schema_template_contract_service_graph.go, model.