### PR TITLE
[bugfix] Fix handling of base URL with multiple slashes (DCNE-532)

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -206,11 +206,10 @@ func (c *Client) useInsecureHTTPClient(insecure bool) *http.Transport {
 }
 
 func (c *Client) MakeFullUrl(method string, path string) (string, error) {
-	if c.platform == "nd" && path != "/login" {
-		path = strings.TrimPrefix(path, "/")
+	path = strings.TrimLeft(path, "/")
+	if c.platform == "nd" && path != "login" {
 		path = fmt.Sprintf("/mso/%v", path)
-	}
-	if !strings.HasPrefix(path, "/") {
+	} else {
 		path = fmt.Sprintf("/%v", path)
 	}
 	url, err := url.Parse(path)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -9,6 +9,7 @@ var TestBaseUrls = [...]string{
 	"https://ndo.host.cisco",
 	"https://ndo.host.cisco/",
 	"https://ndo.host.cisco//",
+	"https://ndo.host.cisco///",
 }
 
 func AssertFullUrl(t *testing.T, baseUrl string, platform string, method string, path string, expected string) {
@@ -38,20 +39,16 @@ func TestMakeFullUrl_Login(t *testing.T) {
 func TestMakeFullUrl_Get(t *testing.T) {
 	expected := "https://ndo.host.cisco/templates/123"
 	expected_nd := "https://ndo.host.cisco/mso/templates/123"
-	path := "/templates/123"
-	for _, baseUrl := range TestBaseUrls {
-		AssertFullUrl(t, baseUrl, "nd", "GET", path, expected_nd)
-		AssertFullUrl(t, baseUrl, "mso", "GET", path, expected)
+	paths := [...]string {
+		"templates/123",
+		"/templates/123",
+		"///templates/123",
 	}
-}
-
-func TestMakeFullUrl_GetNoPrefix(t *testing.T) {
-	expected := "https://ndo.host.cisco/templates/123"
-	expected_nd := "https://ndo.host.cisco/mso/templates/123"
-	path := "templates/123"
 	for _, baseUrl := range TestBaseUrls {
-		AssertFullUrl(t, baseUrl, "nd", "GET", path, expected_nd)
-		AssertFullUrl(t, baseUrl, "mso", "GET", path, expected)
+		for _, path := range paths {
+			AssertFullUrl(t, baseUrl, "nd", "GET", path, expected_nd)
+			AssertFullUrl(t, baseUrl, "mso", "GET", path, expected)
+		}
 	}
 }
 


### PR DESCRIPTION
Improve URL construction to correctly handle base URLs that may be suffixed with multiple slashes, ensuring proper formatting for various request methods. Added unit tests to validate the behavior.