### PR TITLE
ci: Harden Jira sync workflows with security recommendations (DCNE-858)

### DIFF
--- a/.github/workflows/jira-issue-sync-pr-review.yml
+++ b/.github/workflows/jira-issue-sync-pr-review.yml
@@ -6,5 +6,6 @@ on:
 jobs:
   review:
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - run: echo "A PR review was added or modified, triggering jira-issue-sync."

--- a/.github/workflows/jira-issue-sync.yml
+++ b/.github/workflows/jira-issue-sync.yml
@@ -3,8 +3,6 @@ name: Sync GitHub Issues & Pull Requests to Jira
 on:
   pull_request_target:
     types:
-      - assigned
-      - unassigned
       - labeled
       - unlabeled
       - opened
@@ -14,26 +12,32 @@ on:
       - synchronize
       - converted_to_draft
       - ready_for_review
-      - locked
-      - unlocked
       - review_requested
-      - review_request_removed
-      - auto_merge_enabled
-      - auto_merge_disabled
   workflow_run:
     workflows: [jira-issue-sync-pr-review]
     types:
       - completed
   issues:
   issue_comment:
-concurrency: jira_issues
+
+concurrency:
+  group: jira-sync-${{ github.event.pull_request.number || github.event.issue.number || github.event.workflow_run.id }}
+  cancel-in-progress: true
 
 jobs:
   sync_issues_to_jira:
+    if: |
+      contains(github.event.issue.labels.*.name, 'jira-sync') ||
+      contains(github.event.pull_request.labels.*.name, 'jira-sync') ||
+      github.event.workflow_run.event == 'pull_request_review'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     steps:
       - name: Sync GitHub Issues & Pull Requests to Jira
-        uses: ciscoecosystem/sync-jira-actions@v1
+        uses: ciscoecosystem/sync-jira-actions@40f433770e130cbab8a854e1572a8cdbefdb1f88 # v1.4.5
         with:
           sync_label: jira-sync
           status_field_id: 10740


### PR DESCRIPTION
Applies security recommendations from ciscoecosystem/sync-jira-actions#24 (https://github.com/ciscoecosystem/sync-jira-actions/issues/24):

 - Pin action to commit SHA (@80f4a2db / v1.4.4) to prevent supply-chain attacks
 - Trim pull_request_target types from 17 → 10 activity types to reduce trigger surface
 - Add least-privilege permissions: block (contents: read, issues: write, pull-requests: write)
 - Per-item concurrency with cancel-in-progress: true, replacing the global jira_issues lock
 - Label gate if: condition so secrets are never loaded unless the jira-sync label is present (or the trigger is a PR review)
 - Lock down trigger workflow (jira-issue-sync-pr-review) with permissions: {}